### PR TITLE
Add cuda/bin to PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ sudo chmod a+r /usr/local/cuda/include/cudnn.h /usr/local/cuda/lib64/libcudnn*
 ``` bash
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64"
 export CUDA_HOME=/usr/local/cuda
+export PATH="$PATH:/usr/local/cuda/bin"
 ```   
 
 4a. Reload bashrc     


### PR DESCRIPTION
Adding cuda/bin to the PATH prevents the following error not finding the nvcc:

`/bin/sh: 1: nvcc: not found`